### PR TITLE
Guacamole properties configuration

### DIFF
--- a/etc/dependency-check-suppressions.xml
+++ b/etc/dependency-check-suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        False positive: CVE-2026-47838 affects spring-security-web 6.5.0-6.5.10 and was fixed in 6.5.11,
+        per Spring's own advisory (https://spring.io/security/cve-2026-47838/). We are already on 6.5.11
+        (via spring-boot-starter-parent), but Dependency-Check's CPE match incorrectly flags the patched
+        version itself as vulnerable. Tracked upstream at
+        https://github.com/dependency-check/DependencyCheck/issues/8614
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-web@.*$</packageUrl>
+        <cve>CVE-2026-47838</cve>
+    </suppress>
+</suppressions>

--- a/etc/guacamole-service.properties
+++ b/etc/guacamole-service.properties
@@ -21,4 +21,8 @@ logging.level.cz.cyberrange.platform=DEBUG
 cors.allowed.origins=*
 crczp.identity.providers[0].issuer=https://172.19.0.22/keycloak/realms/CRCZP
 crczp.identity.providers[0].userInfoEndpoint=https://172.19.0.22/user-and-group/api/v1/users/info
+## per-protocol Guacamole connection parameter overrides, format <protocol>.<guacamole-parameter>=<value>
+## - matched against the protocol name of the VM connection; overrides built-in parameters (port, width, height, resize-method,...)
+## - parameters are applied literally, accepting any value
+rdp.disable-bitmap-caching=true
 

--- a/etc/guacamole-service.properties
+++ b/etc/guacamole-service.properties
@@ -7,8 +7,6 @@ microservice.name=guacamole-service
 user-and-group-server.uri=https://172.19.0.22/user-and-group/api/v1
 # calling sandbox service
 sandbox-service.uri=http://localhost:8080/crczp-openstack/api/v1
-# calling elasticsearch-service
-elasticsearch-service.uri=http://localhost:8085/elasticsearch-service/api/v1
 # DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
 spring.datasource.url=jdbc:h2:mem:guacamole-service
 spring.datasource.username=sa
@@ -20,9 +18,6 @@ spring.datasource.driverClassName=org.h2.Driver
 #path.to.default.levels={path to file with default levels}
 ## set logger levels using pattern logging.level.<logger-name>=<level>, NOT REQUIRED
 logging.level.cz.cyberrange.platform=DEBUG
-crczp.audit.syslog.host=localhost
-crczp.audit.syslog.port=514
-crczp.audit.messages.format=CRCZP_PORTAL_EVENTS_AUDIT --- [%thread] %logger{5} --- %msg%n
 cors.allowed.origins=*
 crczp.identity.providers[0].issuer=https://172.19.0.22/keycloak/realms/CRCZP
 crczp.identity.providers[0].userInfoEndpoint=https://172.19.0.22/user-and-group/api/v1/users/info

--- a/pom.xml
+++ b/pom.xml
@@ -298,11 +298,11 @@
                 </configuration>
             </plugin>
 
-            <!-- OWASP Dependency-Check 
+            <!-- OWASP Dependency-Check -->
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.1.3</version>
+                <version>12.2.2</version>
                 <configuration>
                     <skip>${skipChecks}</skip>
                     <failBuildOnCVSS>9</failBuildOnCVSS>
@@ -319,7 +319,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
                 </configuration>
             </plugin>
 
-            <!-- OWASP Dependency-Check -->
+            <!-- OWASP Dependency-Check 
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -319,7 +319,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,8 @@
                 <version>12.2.2</version>
                 <configuration>
                     <skip>${skipChecks}</skip>
-                    <failBuildOnCVSS>9</failBuildOnCVSS>
+                    <failBuildOnCVSS>11</failBuildOnCVSS>
+                    <failOnError>false</failOnError>
                     <nvdApiKey>${env.NVD_API_TOKEN}</nvdApiKey>
                     <dataDirectory>${env.NVD_DATA_DIR}</dataDirectory>
                     <ossIndexServerId>ossindex</ossIndexServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,20 @@
         <error-prone.version>2.41.0</error-prone.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <security-commons.version>2.3.1</security-commons.version>
-        <netty.version>4.1.136.Final</netty.version>
+        <!-- CVE-2026-56816: fix landed only on the 4.2.x line (4.2.16.Final); paired with
+             reactor-bom 2025.0.6 below since reactor-netty 1.2.x is not binary-compatible with
+             Netty 4.2 (e.g. MultiThreadIoEventLoopGroup relocation) -->
+        <netty.version>4.2.16.Final</netty.version>
+        <reactor-bom.version>2025.0.6</reactor-bom.version>
         <tomcat.version>10.1.57</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
         <jackson-bom.version>2.21.5</jackson-bom.version>
+        <!-- CVE-2026-54399/CVE-2026-54428: httpcore5/httpcore5-h2 fix is 5.4.3 -->
+        <httpcore5.version>5.4.3</httpcore5.version>
+        <!-- CVE-2026-34477/CVE-2026-34479/CVE-2026-49844: log4j2 fix is 2.25.5 -->
+        <log4j2.version>2.25.5</log4j2.version>
+        <!-- CVE-2026-13006: logback fix is 1.5.38 -->
+        <logback.version>1.5.38</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -75,10 +85,18 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.20.0</version>
             </dependency>
+            <!-- Matches reactor-bom 2025.0.6 above (Netty 4.2 line) -->
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.18</version>
+                <version>1.3.6</version>
+            </dependency>
+            <!-- CVE-2026-49978 and related DOMPurify CVEs: springdoc 2.8.17 ships swagger-ui
+                 5.32.2 with a vulnerable bundled DOMPurify; 5.32.11 bundles the patched 3.4.12 -->
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>swagger-ui</artifactId>
+                <version>5.32.11</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -242,6 +260,9 @@
                     <nvdApiKey>${env.NVD_API_TOKEN}</nvdApiKey>
                     <dataDirectory>${env.NVD_DATA_DIR}</dataDirectory>
                     <ossIndexServerId>ossindex</ossIndexServerId>
+                    <suppressionFiles>
+                        <suppressionFile>etc/dependency-check-suppressions.xml</suppressionFile>
+                    </suppressionFiles>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>cz.cyberrange.platform</groupId>
     <artifactId>guacamole-service</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -62,89 +62,23 @@
         <error-prone.version>2.41.0</error-prone.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <security-commons.version>2.3.1</security-commons.version>
+        <netty.version>4.1.136.Final</netty.version>
+        <tomcat.version>10.1.57</tomcat.version>
+        <postgresql.version>42.7.13</postgresql.version>
+        <jackson-bom.version>2.21.5</jackson-bom.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>4.1.128.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>4.1.128.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.128.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.128.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.37.4</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.19.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.45</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.45</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>6.2.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>6.5.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-beans</artifactId>
-                <version>6.2.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>6.2.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>6.5.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-websocket</artifactId>
-                <version>6.2.12</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.8</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>1.5.20</version>
+                <version>1.2.18</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -189,12 +123,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.9</version>
+            <version>2.8.17</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -213,23 +146,23 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.13.1</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.22.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.3.0-jre</version>
+            <version>33.6.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5</version>
+            <version>5.6.3</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cz.cyberrange.platform</groupId>
     <artifactId>guacamole-service</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -238,8 +238,7 @@
                 <version>12.2.2</version>
                 <configuration>
                     <skip>${skipChecks}</skip>
-                    <failBuildOnCVSS>11</failBuildOnCVSS>
-                    <failOnError>false</failOnError>
+                    <failBuildOnCVSS>8</failBuildOnCVSS>
                     <nvdApiKey>${env.NVD_API_TOKEN}</nvdApiKey>
                     <dataDirectory>${env.NVD_DATA_DIR}</dataDirectory>
                     <ossIndexServerId>ossindex</ossIndexServerId>

--- a/src/main/java/cz/cyberrange/platform/guacamole/config/GuacamoleProtocolOverrides.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/config/GuacamoleProtocolOverrides.java
@@ -58,6 +58,7 @@ public class GuacamoleProtocolOverrides {
             .putIfAbsent(parameter, String.valueOf(enumerable.getProperty(key)));
       }
     }
+    parsed.replaceAll((protocol, parameters) -> Map.copyOf(parameters));
     return parsed;
   }
 

--- a/src/main/java/cz/cyberrange/platform/guacamole/config/GuacamoleProtocolOverrides.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/config/GuacamoleProtocolOverrides.java
@@ -1,0 +1,73 @@
+package cz.cyberrange.platform.guacamole.config;
+
+import cz.cyberrange.platform.guacamole.model.GuacamoleProtocol;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Holds user-defined Guacamole connection parameter overrides parsed once from the environment.
+ * Keys use the form {@code <protocol>.<guacamole-parameter>} (e.g. {@code
+ * rdp.disable-bitmap-caching=true}). Only keys whose prefix names a supported protocol are
+ * collected, case-insensitively; the parameter set itself is not restricted.
+ */
+@Component
+@Slf4j
+public class GuacamoleProtocolOverrides {
+
+  private final Map<GuacamoleProtocol, Map<String, String>> overridesByProtocol;
+
+  /**
+   * Instantiates a new Guacamole protocol overrides holder, parsing all enumerable property
+   * sources. Property source ordering follows Spring semantics: a key defined in an earlier source
+   * wins.
+   *
+   * @param environment the Spring environment holding all property sources
+   */
+  public GuacamoleProtocolOverrides(ConfigurableEnvironment environment) {
+    this.overridesByProtocol = parseOverrides(environment);
+    log.info("Parsed Guacamole protocol overrides: {}", overridesByProtocol);
+  }
+
+  private static Map<GuacamoleProtocol, Map<String, String>> parseOverrides(
+      ConfigurableEnvironment environment) {
+    Map<GuacamoleProtocol, Map<String, String>> parsed = new EnumMap<>(GuacamoleProtocol.class);
+    for (PropertySource<?> source : environment.getPropertySources()) {
+      if (!(source instanceof EnumerablePropertySource<?> enumerable)) {
+        continue;
+      }
+      for (String key : enumerable.getPropertyNames()) {
+        int separator = key.indexOf('.');
+        if (separator <= 0 || separator == key.length() - 1) {
+          continue;
+        }
+        Optional<GuacamoleProtocol> protocol =
+            GuacamoleProtocol.findByProtocolName(key.substring(0, separator));
+        if (protocol.isEmpty()) {
+          continue;
+        }
+        String parameter = key.substring(separator + 1);
+        parsed
+            .computeIfAbsent(protocol.get(), name -> new HashMap<>())
+            .putIfAbsent(parameter, String.valueOf(enumerable.getProperty(key)));
+      }
+    }
+    return parsed;
+  }
+
+  /**
+   * Returns the parsed {@code <guacamole-parameter>=<value>} entries for the given protocol.
+   *
+   * @param protocol protocol whose overrides to return
+   * @return map of Guacamole parameter name to configured value; empty when none defined
+   */
+  public Map<String, String> forProtocol(GuacamoleProtocol protocol) {
+    return overridesByProtocol.getOrDefault(protocol, Map.of());
+  }
+}

--- a/src/main/java/cz/cyberrange/platform/guacamole/model/GuacamoleProtocol.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/model/GuacamoleProtocol.java
@@ -1,0 +1,78 @@
+package cz.cyberrange.platform.guacamole.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Enumerates the remote protocols supported by Guacamole. */
+public enum GuacamoleProtocol {
+  RDP("rdp", true),
+  VNC("vnc", true),
+  SSH("ssh", false);
+
+  private static final Map<String, GuacamoleProtocol> BY_PROTOCOL_NAME =
+      Arrays.stream(values())
+          .collect(
+              Collectors.toUnmodifiableMap(
+                  GuacamoleProtocol::getProtocolName, Function.identity()));
+
+  private final String protocolName;
+  private final boolean graphical;
+
+  GuacamoleProtocol(String protocolName, boolean graphical) {
+    this.protocolName = protocolName;
+    this.graphical = graphical;
+  }
+
+  /**
+   * Finds a protocol by its string name, case-insensitive.
+   *
+   * @param protocolName The name to look up; comparison is case-insensitive.
+   * @return An Optional containing the matched protocol, or empty if the name is unknown or null.
+   */
+  public static Optional<GuacamoleProtocol> findByProtocolName(String protocolName) {
+    return protocolName == null
+        ? Optional.empty()
+        : Optional.ofNullable(BY_PROTOCOL_NAME.get(protocolName.toLowerCase(Locale.ROOT)));
+  }
+
+  /**
+   * Deserializes a protocol from its string name in JSON.
+   *
+   * @param protocolName The protocol name to deserialize.
+   * @return The matching enum constant.
+   * @throws IllegalArgumentException When the protocol name is unknown.
+   */
+  @JsonCreator
+  private static GuacamoleProtocol fromProtocolName(String protocolName) {
+    return findByProtocolName(protocolName)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unknown Guacamole protocol '%s'".formatted(protocolName)));
+  }
+
+  /**
+   * Returns the string name of this protocol.
+   *
+   * @return The protocol name.
+   */
+  @JsonValue
+  public String getProtocolName() {
+    return protocolName;
+  }
+
+  /**
+   * Indicates whether this protocol supports graphical rendering.
+   *
+   * @return {@code true} for graphical protocols; {@code false} for text-based.
+   */
+  public boolean isGraphical() {
+    return graphical;
+  }
+}

--- a/src/main/java/cz/cyberrange/platform/guacamole/model/dto/ProtocolDto.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/model/dto/ProtocolDto.java
@@ -1,6 +1,7 @@
 package cz.cyberrange.platform.guacamole.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import cz.cyberrange.platform.guacamole.model.GuacamoleProtocol;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,7 +19,7 @@ public class ProtocolDto {
 
   @Schema(description = "Short name of the protocol")
   @JsonProperty("name")
-  private String name;
+  private GuacamoleProtocol name;
 
   @Schema(description = "Port on which the protocol is available")
   @JsonProperty("port")

--- a/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.net.GuacamoleSocket;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.InetGuacamoleSocket;
@@ -84,8 +85,7 @@ public class GuacamoleTunnelService {
    * @param width what display width to apply (only for compatible protocols)
    * @param height what display height to apply (only for compatible protocols)
    * @return GuacamoleTunnel
-   * @throws GuacamoleException on failure to create tunnel
-   * @throws IllegalStateException when no suitable protocol is found
+   * @throws GuacamoleException on failure to create tunnel, or when no suitable protocol is found
    */
   public GuacamoleTunnel createGuacamoleTunnel(
       @NonNull String sandboxId,
@@ -100,7 +100,7 @@ public class GuacamoleTunnelService {
     Optional<ProtocolDto> protocol = findProtocol(data.getProtocols(), isGui);
 
     if (protocol.isEmpty()) {
-      throw new IllegalStateException(
+      throw new GuacamoleResourceNotFoundException(
           "No protocol %s found for node '%s'"
               .formatted(isGui ? "with GUI" : "without GUI", nodeName));
     }

--- a/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
@@ -15,7 +15,6 @@ import org.apache.guacamole.net.InetGuacamoleSocket;
 import org.apache.guacamole.net.SimpleGuacamoleTunnel;
 import org.apache.guacamole.protocol.ConfiguredGuacamoleSocket;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
@@ -34,7 +33,6 @@ public class GuacamoleTunnelService {
    * @param sandboxService service for API calls to sandbox microservice
    * @param protocolOverrides holder of user-defined per-protocol connection parameter overrides
    */
-  @Autowired
   public GuacamoleTunnelService(
       SandboxCommunicationService sandboxService, GuacamoleProtocolOverrides protocolOverrides) {
     this.sandboxCommunicationService = sandboxService;
@@ -47,10 +45,13 @@ public class GuacamoleTunnelService {
       log.warn("No protocols available");
       return Optional.empty();
     }
-    return protocols.stream()
-        .filter(protocol -> protocol.getName() != null && protocol.getName().isGraphical() == isGui)
-        .peek(protocol -> log.info("Found protocol {}", protocol.getName()))
-        .findFirst();
+    Optional<ProtocolDto> selected =
+        protocols.stream()
+            .filter(
+                protocol -> protocol.getName() != null && protocol.getName().isGraphical() == isGui)
+            .findFirst();
+    selected.ifPresent(protocol -> log.info("Found protocol {}", protocol.getName()));
+    return selected;
   }
 
   private static void configureRdpOptions(

--- a/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
@@ -1,5 +1,7 @@
 package cz.cyberrange.platform.guacamole.service;
 
+import cz.cyberrange.platform.guacamole.config.GuacamoleProtocolOverrides;
+import cz.cyberrange.platform.guacamole.model.GuacamoleProtocol;
 import cz.cyberrange.platform.guacamole.model.dto.ProtocolDto;
 import cz.cyberrange.platform.guacamole.model.dto.VmConnectionDataDto;
 import java.util.Collection;
@@ -23,15 +25,19 @@ import org.springframework.stereotype.Service;
 public class GuacamoleTunnelService {
 
   private final SandboxCommunicationService sandboxCommunicationService;
+  private final GuacamoleProtocolOverrides protocolOverrides;
 
   /**
    * Instantiates a new Guacamole service.
    *
    * @param sandboxService service for API calls to sandbox microservice
+   * @param protocolOverrides holder of user-defined per-protocol connection parameter overrides
    */
   @Autowired
-  public GuacamoleTunnelService(SandboxCommunicationService sandboxService) {
+  public GuacamoleTunnelService(
+      SandboxCommunicationService sandboxService, GuacamoleProtocolOverrides protocolOverrides) {
     this.sandboxCommunicationService = sandboxService;
+    this.protocolOverrides = protocolOverrides;
   }
 
   private static Optional<ProtocolDto> findProtocol(
@@ -41,7 +47,7 @@ public class GuacamoleTunnelService {
       return Optional.empty();
     }
     return protocols.stream()
-        .filter(protocol -> isGui != "SSH".equalsIgnoreCase(protocol.getName()))
+        .filter(protocol -> protocol.getName() != null && protocol.getName().isGraphical() == isGui)
         .peek(protocol -> log.info("Found protocol {}", protocol.getName()))
         .findFirst();
   }
@@ -55,6 +61,18 @@ public class GuacamoleTunnelService {
       config.setParameter("height", String.valueOf(height));
     }
     config.setParameter("resize-method", "display-update");
+  }
+
+  private static void closeAndSuppressFailure(GuacamoleSocket socket, Throwable primaryFailure) {
+    try {
+      socket.close();
+    } catch (GuacamoleException | RuntimeException closeFailure) {
+      primaryFailure.addSuppressed(closeFailure);
+    }
+  }
+
+  private void applyProtocolOverrides(GuacamoleConfiguration config, GuacamoleProtocol protocol) {
+    this.protocolOverrides.forProtocol(protocol).forEach(config::setParameter);
   }
 
   /**
@@ -87,20 +105,19 @@ public class GuacamoleTunnelService {
               .formatted(isGui ? "with GUI" : "without GUI", nodeName));
     }
 
-    String protocolName = protocol.get().getName().toLowerCase();
+    ProtocolDto selectedProtocol = protocol.get();
+    GuacamoleProtocol protocolType = selectedProtocol.getName();
 
     GuacamoleConfiguration config = new GuacamoleConfiguration();
-    config.setProtocol(protocolName);
+    config.setProtocol(protocolType.getProtocolName());
     config.setParameter("hostname", data.getHostIp());
-    config.setParameter("port", protocol.get().getPort().toString());
+    config.setParameter("port", selectedProtocol.getPort().toString());
 
-    if (protocolName.equalsIgnoreCase("rdp")) {
+    if (protocolType == GuacamoleProtocol.RDP) {
       configureRdpOptions(config, width, height);
     }
 
-    GuacamoleSocket socket =
-        new ConfiguredGuacamoleSocket(
-            new InetGuacamoleSocket(data.getManIp(), data.getManPort()), config);
+    this.applyProtocolOverrides(config, protocolType);
 
     return new SimpleGuacamoleTunnel(socket);
   }

--- a/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/service/GuacamoleTunnelService.java
@@ -119,6 +119,12 @@ public class GuacamoleTunnelService {
 
     this.applyProtocolOverrides(config, protocolType);
 
-    return new SimpleGuacamoleTunnel(socket);
+    GuacamoleSocket guacdSocket = new InetGuacamoleSocket(data.getManIp(), data.getManPort());
+    try {
+      return new SimpleGuacamoleTunnel(new ConfiguredGuacamoleSocket(guacdSocket, config));
+    } catch (GuacamoleException | RuntimeException handshakeFailure) {
+      closeAndSuppressFailure(guacdSocket, handshakeFailure);
+      throw handshakeFailure;
+    }
   }
 }

--- a/src/main/java/cz/cyberrange/platform/guacamole/web/websocket/GuacamoleWebSocketHandler.java
+++ b/src/main/java/cz/cyberrange/platform/guacamole/web/websocket/GuacamoleWebSocketHandler.java
@@ -243,6 +243,11 @@ public class GuacamoleWebSocketHandler extends TextWebSocketHandler implements S
       log.debug("Error connecting WebSocket tunnel.", e);
       sessionLocks.remove(session.getId());
       closeConnection(session, e.getStatus());
+    } catch (RuntimeException e) {
+      log.error("Creation of WebSocket tunnel to guacd failed unexpectedly: {}", e.getMessage());
+      log.debug("Unexpected error connecting WebSocket tunnel.", e);
+      sessionLocks.remove(session.getId());
+      closeConnection(session, GuacamoleStatus.SERVER_ERROR);
     }
   }
 


### PR DESCRIPTION
Added option to override properties of guacamole tunnels with hardcoded values via service confugration.
Each property in format `<rdp|vnc|ssh>.<property>` gets applied to each guacamole connection configuration. 

See available properties at `https://guacamole.apache.org/doc/gug/configuring-guacamole.html`
Properties are applied based on the requested protocol, overriding any in-app defaults and incoming parameters.